### PR TITLE
Update to latest Fody version with non-broken cecil

### DIFF
--- a/src/Rothko.csproj
+++ b/src/Rothko.csproj
@@ -13,7 +13,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>2169171e</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>cc727fb4</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -124,12 +124,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\packages\Fody.1.25.0\build\Fody.targets" Condition="Exists('..\..\..\packages\Fody.1.25.0\build\Fody.targets')" />
+  <Import Project="..\..\..\packages\Fody.1.26.4\build\Fody.targets" Condition="Exists('..\..\..\packages\Fody.1.26.4\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\Fody.1.25.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Fody.1.25.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Fody.1.26.4\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Fody.1.26.4\build\Fody.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fody" version="1.25.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Fody" version="1.26.4" targetFramework="net45" developmentDependency="true" />
   <package id="NullGuard.Fody" version="1.2.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Looks like the latest (1.26.4) version of Fody ships a Mono.Cecil that works in VS2015.