### PR TITLE
Put extensions in their own namespace so they don't clash

### DIFF
--- a/src/Infrastructure/ExceptionExtensions.cs
+++ b/src/Infrastructure/ExceptionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 
-namespace Rothko
+namespace Rothko.Extensions
 {
     public static class ExceptionExtensions
     {

--- a/src/Processes/ProcessLocator.cs
+++ b/src/Processes/ProcessLocator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Rothko.Extensions;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;


### PR DESCRIPTION
The extensions being in the root namespace clash with others that are defined in other assemblies. Having extensions in the root namespace causes them to be imported automatically (polluting the name space) and makes it impossible to fix clashes :/

Also, maybe it's a good idea to create a tracking branch with a more generic name in Rothko to pull these PRs into? I'm partial to having a branch called "kittens", that's always a good name for generic things. :wink: 