### PR TITLE
Set directories/files to read only before deleting

### DIFF
--- a/src/DirectoryInfo.cs
+++ b/src/DirectoryInfo.cs
@@ -110,7 +110,7 @@ namespace Rothko
             }
 
             // Make sure the directory is not readonly
-            inner.Attributes = FileAttributes.ReadOnly;
+            inner.Attributes = FileAttributes.Normal;
             inner.Delete(recursive);
         }
 


### PR DESCRIPTION
This is inspired by a bug found in GitHub Desktop for Windows.